### PR TITLE
Extract multiple hosts from .nessus report

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Usage
 
 ::
 
-    from nessus_parser import parse_nessus_file, parse_nessus_xml
+    from nessus_report_parser import parse_nessus_file, parse_nessus_xml
     parse_nessus_file('path/to/nessus/file.nessus')
 

--- a/nessus_report_parser/model/report.py
+++ b/nessus_report_parser/model/report.py
@@ -17,7 +17,7 @@ class Report(UserDict):
 
         properties = {
             'name': elem.attrib.get('name'),
-            'host': ReportHost.from_etree(elem.find('ReportHost'))
+            'hosts': [ReportHost.from_etree(el) for el in elem.findall('ReportHost')]
         }
 
         return Report(properties)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except:
 
 setup(
     name='nessus_report_parser',
-    version="0.2.8.2",
+    version="0.2.8.3",
     description='A wrapper around the tapioca-nessus_report_parser for translating the'
                 ' Nessus API documents into Python Objects',
     long_description=long_description,


### PR DESCRIPTION
This PR has two tiny changes:

1. Instead of only extracting a single host and its data from the report, all hosts will be converted from the .nessus file to Python objects.
2. Trivial fix to the README example.